### PR TITLE
Seprate jdk

### DIFF
--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -16,7 +16,6 @@
       - apt-transport-https
       - gnupg
       - net-tools
-      - openjdk-11-jdk
     state: present
     update_cache: true
 

--- a/tasks/setup-redhat.yml
+++ b/tasks/setup-redhat.yml
@@ -4,7 +4,6 @@
   ansible.builtin.package:
     name:
       - curl
-      - java-11-openjdk-devel
     state: present
 
 - name: Add Jenkins repo GPG key.


### PR DESCRIPTION
The JDK package may not available in OS repo. e.g. jdk 17 is not available in CentOS 7.x.

Another JDK role is required to deploy JDK.