### PR TITLE
Update java bin name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ jenkins_url: "{{ jenkins_schema }}://{{ jenkins_server_name }}/"
 jenkins_webroot_directory: '/var/cache/jenkins/war'
 
 # For plugin
-java_bin: "{{ java_home | default('') | ternary(java_home + '/bin/java', 'java') }}"
+jenkins_java_bin: "{{ jenkins_java_home | default('') | ternary(jenkins_java_home + '/bin/java', 'java') }}"
 
 jenkins_plugin_manager_version: "2.12.9"
 jenkins_plugin_manager_url_prefix: "https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download"
@@ -73,7 +73,7 @@ jenkins_plugin_manager_non_proxy_hosts: "{{ '-Dhttp.nonProxyHosts=' ~ jenkins_no
 
 # no double quotes needed if `>` is used
 jenkins_plugin_installation_cmd: >
-  {{ java_bin }}
+  {{ jenkins_java_bin }}
   {{ jenkins_plugin_manager_proxy_port }}
   {{ jenkins_plugin_manager_proxy_host }}
   {{ jenkins_plugin_manager_non_proxy_hosts }}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,11 +3,11 @@
   hosts: all
   vars:
     jdk_version: 21.0.2
-    java_home: /opt/jdk-21.0.2
+    jenkins_java_home: /opt/jdk-21.0.2
     jenkins_plugin_file: plugins.txt
     jenkins_jcasc_template: jenkins.yaml.j2
     jenkins_systemd_unit_envs:
-      java_home: "{{ java_home }}"
+      java_home: "{{ jenkins_java_home }}"
   tasks:
     - name: "Include zhan9san.java"
       ansible.builtin.include_role:


### PR DESCRIPTION
var-naming[no-role-prefix]: Variables names from within roles should use role_name_ as a prefix. Underlines are accepted before the prefix.

https://ansible.readthedocs.io/projects/lint/rules/var-naming/
